### PR TITLE
Bridge mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ stop:
 
 .PHONY: destroy
 destroy: stop
-	docker-compose rm -fv
+	docker-compose rm -f --all
 	[ -z .docker ] || rm -rf .docker
 	[ -z docker.tar.gz ] || rm -rf docker.tar.gz
 

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -1,0 +1,79 @@
+version: "2"
+
+services:
+  zk:
+    image: bobrik/zookeeper
+    network_mode: host
+    environment:
+      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+      ZK_ID: 1
+
+  mesos-master:
+    image: mesosphere/mesos-master:1.0.0-2.0.89.ubuntu1404
+    network_mode: host
+    environment:
+      MESOS_ZK: zk://127.0.0.1:2181/mesos
+      MESOS_QUORUM: 1
+      MESOS_CLUSTER: docker-compose
+      MESOS_REGISTRY: replicated_log # default is in_memory for some reason
+      MESOS_HOSTNAME: ${DOCKER_IP}
+      LIBPROCESS_IP: ${DOCKER_IP}
+    volumes:
+      - ./docker.tar.gz:/etc/docker.tar.gz
+    depends_on:
+      - zk
+
+  mesos-slave-one:
+    image: mesosphere/mesos-slave:1.0.0-2.0.89.ubuntu1404
+    network_mode: host
+    pid: host
+    environment:
+      MESOS_MASTER: zk://127.0.0.1:2181/mesos
+      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_PORT: 5051
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_HOSTNAME: ${DOCKER_IP}
+      LIBPROCESS_IP: ${DOCKER_IP}
+      MESOS_WORK_DIR: /tmp/mesos
+    volumes:
+      - ./docker.tar.gz:/etc/docker.tar.gz
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - /usr/bin/docker:/usr/bin/docker
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zk
+
+  # slave-two:
+  #   image: mesosphere/mesos-slave:1.0.0-2.0.89.ubuntu1404
+  #   network_mode: host
+  #   pid: host
+  #   environment:
+  #     MESOS_MASTER: zk://127.0.0.1:2181/mesos
+  #     MESOS_CONTAINERIZERS: docker,mesos
+  #     MESOS_PORT: 5052
+  #     MESOS_RESOURCES: ports(*):[12000-12999]
+  #     MESOS_HOSTNAME: ${DOCKER_IP}
+  #     LIBPROCESS_IP: ${DOCKER_IP}
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup
+  #     - /usr/local/bin/docker:/usr/bin/docker
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   depends_on:
+  #     - zk
+
+  marathon:
+    image: mesosphere/marathon:v1.2.0-RC6
+    network_mode: host
+    environment:
+      MARATHON_MASTER: zk://127.0.0.1:2181/mesos
+    volumes:
+      - ./docker.tar.gz:/etc/docker.tar.gz
+    depends_on:
+      - zk
+
+  # chronos:
+  #   image: mesosphere/chronos:chronos-2.4.0-0.1.20151007110204.ubuntu1404-mesos-0.24.1-0.2.35.ubuntu1404
+  #   command: /usr/bin/chronos run_jar --http_port 8888 --master zk://127.0.0.1:2181/mesos --zk_hosts zk://127.0.0.1:2181/mesos
+  #   network_mode: host
+  #   depends_on:
+  #     - zk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,21 +3,26 @@ version: "2"
 services:
   zk:
     image: bobrik/zookeeper
-    network_mode: host
+    network_mode: bridge
+    ports:
+      - 2181:2181
     environment:
       ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
       ZK_ID: 1
 
   mesos-master:
     image: mesosphere/mesos-master:1.0.0-2.0.89.ubuntu1404
-    network_mode: host
+    network_mode: bridge
+    links:
+      - zk
+    ports:
+      - 5050:5050
     environment:
-      MESOS_ZK: zk://127.0.0.1:2181/mesos
+      MESOS_ZK: zk://zk:2181/mesos
       MESOS_QUORUM: 1
       MESOS_CLUSTER: docker-compose
       MESOS_REGISTRY: replicated_log # default is in_memory for some reason
-      MESOS_HOSTNAME: ${DOCKER_IP}
-      LIBPROCESS_IP: ${DOCKER_IP}
+      MESOS_HOSTNAME: mesos-master
     volumes:
       - ./docker.tar.gz:/etc/docker.tar.gz
     depends_on:
@@ -25,15 +30,19 @@ services:
 
   mesos-slave-one:
     image: mesosphere/mesos-slave:1.0.0-2.0.89.ubuntu1404
-    network_mode: host
+    network_mode: bridge
+    links:
+      - zk
+      - mesos-master:mesos-master
+    ports:
+      - 5051:5051
     pid: host
     environment:
-      MESOS_MASTER: zk://127.0.0.1:2181/mesos
+      MESOS_MASTER: zk://zk:2181/mesos
       MESOS_CONTAINERIZERS: docker,mesos
       MESOS_PORT: 5051
       MESOS_RESOURCES: ports(*):[11000-11999]
-      MESOS_HOSTNAME: ${DOCKER_IP}
-      LIBPROCESS_IP: ${DOCKER_IP}
+      MESOS_HOSTNAME: mesos-slave-one
       MESOS_WORK_DIR: /tmp/mesos
     volumes:
       - ./docker.tar.gz:/etc/docker.tar.gz
@@ -42,10 +51,16 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zk
+      - mesos-master
 
   # slave-two:
   #   image: mesosphere/mesos-slave:1.0.0-2.0.89.ubuntu1404
-  #   network_mode: host
+  #   network_mode: bridge
+    #links:
+      #- zk:zk
+      #- mesos-slave-two:mesos-slave-two
+    #ports:
+      #- 5050:5050
   #   pid: host
   #   environment:
   #     MESOS_MASTER: zk://127.0.0.1:2181/mesos
@@ -53,7 +68,6 @@ services:
   #     MESOS_PORT: 5052
   #     MESOS_RESOURCES: ports(*):[12000-12999]
   #     MESOS_HOSTNAME: ${DOCKER_IP}
-  #     LIBPROCESS_IP: ${DOCKER_IP}
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup
   #     - /usr/local/bin/docker:/usr/bin/docker
@@ -63,17 +77,27 @@ services:
 
   marathon:
     image: mesosphere/marathon:v1.2.0-RC6
-    network_mode: host
+    network_mode: bridge
+    links:
+      - zk
+      - mesos-master
+      - mesos-slave-one
+    ports:
+      - 80:80
+      - 8080:8080
     environment:
-      MARATHON_MASTER: zk://127.0.0.1:2181/mesos
+      MARATHON_MASTER: zk://zk:2181/marathon 
+      MARATHON_ZK: zk://zk:2181/marathon
     volumes:
       - ./docker.tar.gz:/etc/docker.tar.gz
     depends_on:
       - zk
+      - mesos-master
+      - mesos-slave-one
 
   # chronos:
   #   image: mesosphere/chronos:chronos-2.4.0-0.1.20151007110204.ubuntu1404-mesos-0.24.1-0.2.35.ubuntu1404
   #   command: /usr/bin/chronos run_jar --http_port 8888 --master zk://127.0.0.1:2181/mesos --zk_hosts zk://127.0.0.1:2181/mesos
-  #   network_mode: host
+  #   network_mode: bridge
   #   depends_on:
   #     - zk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       MESOS_CLUSTER: docker-compose
       MESOS_REGISTRY: replicated_log # default is in_memory for some reason
       MESOS_HOSTNAME: mesos-master
+      MESOS_LOG_DIR: /var/log/mesos
+      MESOS_EXTERNAL_LOG_DIR: /var/log/mesos_external
     volumes:
       - ./docker.tar.gz:/etc/docker.tar.gz
     depends_on:
@@ -44,6 +46,8 @@ services:
       MESOS_RESOURCES: ports(*):[11000-11999]
       MESOS_HOSTNAME: mesos-slave-one
       MESOS_WORK_DIR: /tmp/mesos
+      MESOS_LOG_DIR: /var/log/mesos
+      MESOS_EXTERNAL_LOG_DIR: /var/log/mesos_external
     volumes:
       - ./docker.tar.gz:/etc/docker.tar.gz
       - /sys/fs/cgroup:/sys/fs/cgroup
@@ -86,7 +90,7 @@ services:
       - 80:80
       - 8080:8080
     environment:
-      MARATHON_MASTER: zk://zk:2181/marathon 
+      MARATHON_MASTER: zk://zk:2181/mesos 
       MARATHON_ZK: zk://zk:2181/marathon
     volumes:
       - ./docker.tar.gz:/etc/docker.tar.gz


### PR DESCRIPTION
This PR makes the primary dockerfile use bridge mode networking instead of host mode networking. This resolves the issue of running this on Mac OSX which runs docker in a vm and has no official support of host mode networking.

It also includes new make targets to allow for docker credentials to be loaded within marathon, given `DOCKER_USERNAME` and `DOCKER_PASSWORD` env vars are set.
