### PR TITLE
prevent docker-login from printing creds to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ mytest:
 	cp ~/.docker/config.json ./.docker
 
 docker-login:
-	docker login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)"
+	@docker login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)"
 
 .PHONY: prepare
 prepare: docker-login .docker
@@ -39,4 +39,3 @@ destroy: stop
 	docker-compose rm -fv
 	[ -z .docker ] || rm -rf .docker
 	[ -z docker.tar.gz ] || rm -rf docker.tar.gz
-


### PR DESCRIPTION
Docker Hub credentials are no longer written to stdout when `docker-login` is called